### PR TITLE
Extend behaviour of j and k with prefix args.

### DIFF
--- a/Cask
+++ b/Cask
@@ -15,4 +15,6 @@
 (development
  (depends-on "ecukes")
  (depends-on "espuds")
- (depends-on "undercover"))
+ (depends-on "undercover")
+ (depends-on "ert-runner")
+ (depends-on "f"))

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:
 	@cask
 
-test: ecukes ert
+test: ert ecukes
 
 ecukes:
 	@cask exec ecukes

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 all:
 	@cask
 
-test: ecukes
+test: ecukes ert
 
 ecukes:
 	@cask exec ecukes
+
+ert:
+	@cask exec ert-runner
 
 .PHONY: test ecukes

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ ecukes:
 ert:
 	@cask exec ert-runner
 
-.PHONY: test ecukes
+.PHONY: test ecukes ert

--- a/evil-hardcore.el
+++ b/evil-hardcore.el
@@ -39,17 +39,21 @@
                       (kbd "g k") #'evil-previous-line)
     map))
 
-(evil-define-motion evil-hardcore-jump-down (_)
+(evil-define-motion evil-hardcore-jump-down (count)
   "Jump down a number of lines using the home row keys."
   :type line
   :jump t ; so you can get back to where you were with ``
-  (vertigo--jump #'evil-next-line "Jump down: "))
+  (if count
+      (evil-next-line count)
+    (vertigo--jump #'evil-next-line "Jump down: ")))
 
-(evil-define-motion evil-hardcore-jump-up (_)
+(evil-define-motion evil-hardcore-jump-up (count)
   "Jump up a number of lines using the home row keys."
   :type line
   :jump t
-  (vertigo--jump #'evil-previous-line "Jump up: "))
+  (if count
+      (evil-previous-line count)
+    (vertigo--jump #'evil-previous-line "Jump up: ")))
 
 ;; Needs to be at the end so that everything else is defined.
 (define-minor-mode evil-hardcore-local-mode

--- a/features/evil-hardcore.feature
+++ b/features/evil-hardcore.feature
@@ -1,0 +1,5 @@
+Feature: evil-hardcore-mode
+
+  Scenario: evil-hardcore-global-mode is active
+    Given the buffer contains an extract from Frankenstein
+    Then evil-hardcore-global-mode should be active

--- a/features/j-and-k.feature
+++ b/features/j-and-k.feature
@@ -1,4 +1,4 @@
-Feature: j and k keys do vertigo jumps without a prefix arg, and normal evil motions with a prefix arg.
+Feature: j and k keys do vertigo jumps without a prefix arg, and normal evil motions with a prefix arg
 
   Scenario: j key jumps down
     Given the buffer contains an extract from Frankenstein

--- a/features/j-and-k.feature
+++ b/features/j-and-k.feature
@@ -1,23 +1,7 @@
-Feature: j and k keys do vertigo jumps
+Feature: j and k keys do vertigo jumps without a prefix arg, and normal evil motions with a prefix arg.
 
   Scenario: j key jumps down
-    Given the buffer is empty
-    When I insert:
-      """
-      It was on a dreary night of November that I
-      beheld the accomplishment of my toils. With
-      an anxiety that almost amounted to agony,
-      collected the instruments of life around me,
-      that I might infuse a spark of being into
-      the lifeless thing that lay at my feet. It
-      was already one in the morning; the rain
-      pattered dismally against the panes, and my
-      candle was nearly burnt out, when, by the
-      glimmer of the half-extinguished light, I
-      saw the dull yellow eye of the creature
-      open; it breathed hard, and a convulsive
-      motion agitated its limbs.
-      """
+    Given the buffer contains an extract from Frankenstein
     And I place the cursor before "accomplishment"
     And I start an action chain
     And I press "j"
@@ -25,25 +9,61 @@ Feature: j and k keys do vertigo jumps
     Then the cursor should be before "the"
 
   Scenario: k key jumps up
-    Given the buffer is empty
-    When I insert:
-      """
-      It was on a dreary night of November that I
-      beheld the accomplishment of my toils. With
-      an anxiety that almost amounted to agony,
-      collected the instruments of life around me,
-      that I might infuse a spark of being into
-      the lifeless thing that lay at my feet. It
-      was already one in the morning; the rain
-      pattered dismally against the panes, and my
-      candle was nearly burnt out, when, by the
-      glimmer of the half-extinguished light, I
-      saw the dull yellow eye of the creature
-      open; it breathed hard, and a convulsive
-      motion agitated its limbs.
-      """
+    Given the buffer contains an extract from Frankenstein
     And I place the cursor before "nearly"
     And I start an action chain
     And I press "k"
     And I type "j"
     Then the cursor should be before "accomplishment"
+
+  Scenario: j key acts normally with prefix arg
+    Given the buffer contains an extract from Frankenstein
+    And I place the cursor before "nearly"
+    And I start an action chain
+    And I press "3"
+    And I press "j"
+    Then the cursor should be before "eathed"
+
+  Scenario: k key acts normally with prefix arg
+    Given the buffer contains an extract from Frankenstein
+    And I place the cursor before "eathed"
+    And I start an action chain
+    And I press "3"
+    And I press "k"
+    Then the cursor should be before "nearly"
+
+  Scenario: j key acts linewise with operators
+    Given the buffer contains an extract from Frankenstein
+    And I place the cursor before "accomplishment"
+    And I start an action chain
+    And I press "d"
+    And I press "j"
+    And I type "j"
+    Then the cursor should be before "glimmer"
+    And the buffer should contain:
+      """
+      It was on a dreary night of November that I
+      glimmer of the half-extinguished light, I
+      saw the dull yellow eye of the creature
+      open; it breathed hard, and a convulsive
+      motion agitated its limbs.
+      """
+
+  Scenario: k key acts linewise with operators
+    Given the buffer contains an extract from Frankenstein
+    And I place the cursor before "half"
+    And I start an action chain
+    And I press "d"
+    And I press "3"
+    And I press "k"
+    Then the cursor should be before "yellow"
+    And the buffer should contain:
+      """
+      It was on a dreary night of November that I beheld
+      the accomplishment of my toils. With an anxiety
+      that almost amounted to agony, collected the
+      instruments of life around me, that I might infuse
+      a spark of being into the lifeless thing that lay
+      yellow eye of the creature open; it breathed hard,
+      and a convulsive motion agitated its limbs.
+      """

--- a/features/step-definitions/evil-hardcore-steps.el
+++ b/features/step-definitions/evil-hardcore-steps.el
@@ -46,6 +46,11 @@ buffer, wiping it beforehand."
               (message "Expected\n%s\nto be:\n%s"))
           (cl-assert (string= expected actual) nil message expected actual))))
 
+(Then "^evil-hardcore-global-mode should be active$"
+      "Asserts that evil-hardcore-global-mode is active."
+      (lambda ()
+        (cl-assert evil-hardcore-global-mode nil "Expected evil-hardcore-global-mode to be t")))
+
 (And "^I have \"\\(.+\\)\"$"
   (lambda (something)
     ;; ...

--- a/features/step-definitions/evil-hardcore-steps.el
+++ b/features/step-definitions/evil-hardcore-steps.el
@@ -29,16 +29,6 @@ buffer, wiping it beforehand."
     (erase-buffer)
     (evil-hardcore--insert-frankenstein)))
 
-(Given "^I have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))
-
-(When "^I have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))
-
 (Then "^the buffer should contain\\(?: \"\\(.+\\)\"\\|:\\)$"
       "Asserts that the current buffer contents are the given string."
       (lambda (expected)
@@ -50,13 +40,3 @@ buffer, wiping it beforehand."
       "Asserts that evil-hardcore-global-mode is active."
       (lambda ()
         (cl-assert evil-hardcore-global-mode nil "Expected evil-hardcore-global-mode to be t")))
-
-(And "^I have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))
-
-(But "^I should not have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))

--- a/features/step-definitions/evil-hardcore-steps.el
+++ b/features/step-definitions/evil-hardcore-steps.el
@@ -5,6 +5,30 @@
 ;; I think this is a very good way of doing things; it gives you a rather
 ;; obvious template for what you need to do. All tools should be like this.
 
+(require 'cl-lib)
+
+(defun evil-hardcore--insert-frankenstein ()
+  (interactive)
+  (insert
+"It was on a dreary night of November that I beheld
+the accomplishment of my toils. With an anxiety
+that almost amounted to agony, collected the
+instruments of life around me, that I might infuse
+a spark of being into the lifeless thing that lay
+at my feet. It was already one in the morning; the
+rain pattered dismally against the panes, and my
+candle was nearly burnt out, when, by the glimmer
+of the half-extinguished light, I saw the dull
+yellow eye of the creature open; it breathed hard,
+and a convulsive motion agitated its limbs."))
+
+(Given "^the buffer contains an extract from Frankenstein$"
+  "Puts the first paragraph of C5 of Frankenstein into the
+buffer, wiping it beforehand."
+  (lambda ()
+    (erase-buffer)
+    (evil-hardcore--insert-frankenstein)))
+
 (Given "^I have \"\\(.+\\)\"$"
   (lambda (something)
     ;; ...
@@ -15,10 +39,12 @@
     ;; ...
     ))
 
-(Then "^I should have \"\\(.+\\)\"$"
-  (lambda (something)
-    ;; ...
-    ))
+(Then "^the buffer should contain\\(?: \"\\(.+\\)\"\\|:\\)$"
+      "Asserts that the current buffer contents are the given string."
+      (lambda (expected)
+        (let ((actual (buffer-string))
+              (message "Expected\n%s\nto be:\n%s"))
+          (cl-assert (string= expected actual) nil message expected actual))))
 
 (And "^I have \"\\(.+\\)\"$"
   (lambda (something)

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -16,8 +16,8 @@
 
 ;; Ensure that we don't load old byte-compiled versions
 (let ((load-prefer-newer t))
-  ;; (require 'evil)
-  ;; (require 'vertigo)
+  (require 'evil)
+  (require 'vertigo)
   (require 'evil-hardcore)
   (require 'espuds)
   (require 'ert))

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -40,4 +40,6 @@
  )
 
 (Fail
- (princ (buffer-string)))
+ (princ "«")
+ (princ (buffer-string))
+ (princ "»"))

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -43,3 +43,5 @@
  (princ "«")
  (princ (buffer-string))
  (princ "»"))
+
+

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -22,6 +22,8 @@
   (require 'espuds)
   (require 'ert))
 
+(evil-hardcore-global-mode)
+
 (Setup
  ;; Before anything has run
  )

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -38,3 +38,6 @@
 (Teardown
  ;; After when everything has been run
  )
+
+(Fail
+ (princ (buffer-string)))

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -43,5 +43,3 @@
  (princ "«")
  (princ (buffer-string))
  (princ "»"))
-
-

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -24,8 +24,8 @@
 
 
 (Setup
-  (evil-mode)
-  (evil-hardcore-global-mode))
+  (evil-mode 1)
+  (evil-hardcore-global-mode 1))
 
 (Before
  ;; Before each scenario is run

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -24,7 +24,8 @@
 
 
 (Setup
- (evil-hardcore-global-mode))
+  (evil-mode)
+  (evil-hardcore-global-mode))
 
 (Before
  ;; Before each scenario is run

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -22,11 +22,9 @@
   (require 'espuds)
   (require 'ert))
 
-(evil-hardcore-global-mode)
 
 (Setup
- ;; Before anything has run
- )
+ (evil-hardcore-global-mode))
 
 (Before
  ;; Before each scenario is run

--- a/test/evil-hardcore-test.el
+++ b/test/evil-hardcore-test.el
@@ -1,0 +1,8 @@
+(ert-deftest eh/functions-bound ()
+  (should (fboundp 'evil-hardcore-jump-down))
+  (should (fboundp 'evil-hardcore-jump-up))
+  (should (fboundp 'evil-hardcore-local-mode))
+  (should (fboundp 'evil-hardcore-global-mode)))
+
+(ert-deftest eh/variables-bound ()
+  (should (boundp 'evil-hardcore-map)))

--- a/test/evil-hardcore-test.el
+++ b/test/evil-hardcore-test.el
@@ -6,3 +6,11 @@
 
 (ert-deftest eh/variables-bound ()
   (should (boundp 'evil-hardcore-map)))
+
+(ert-deftest eh/keys-bound ()
+  (evil-local-mode 1)
+  (evil-hardcore-local-mode 1)
+  (should (eq (key-binding "k") 'evil-binding-jump-up))
+  (should (eq (key-binding "j") 'evil-binding-jump-down))
+  (evil-local-mode -1)
+  (evil-hardcore-local-mode -1))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,5 @@
+(require 'f)
+
+(let* ((test-path (f-dirname (f-this-file)))
+       (code-path (f-parent test-path)))
+  (require 'evil-hardcore (f-expand "evil-hardcore.el" code-path)))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,4 +1,5 @@
 (require 'f)
+(require 'ert)
 
 (let* ((test-path (f-dirname (f-this-file)))
        (code-path (f-parent test-path)))


### PR DESCRIPTION
See #1. Test coverage for this is not yet quite complete -- ideally,
there should be several tests for each feature. However, there is a
reasonable amount of coverage.

The `.feature` files have also been refactored; the example buffer they now use is wrapped up into `Given the buffer contains an extract from Frankenstein`, which sets the buffer contents to be the first paragraph of chapter 5 of Frankenstein, by Mary Shelley. This has reduced the LOC significantly.